### PR TITLE
Regen: update lib path and usage instructions in deps

### DIFF
--- a/firmware/pac/src/lib.rs
+++ b/firmware/pac/src/lib.rs
@@ -1,3 +1,3 @@
 #![no_std]
 
-compile_error!("run the `regen` tool before compiling this crate");
+compile_error!("run the `host/regen/` tool before compiling this crate");

--- a/host/regen/src/main.rs
+++ b/host/regen/src/main.rs
@@ -15,8 +15,8 @@ mod verify;
 use std::{fs, path::Path};
 
 fn main() -> Result<(), anyhow::Error> {
-    gen_cm(Path::new("../../shared/cm/src/lib.rs"))?;
-    gen_nrf52(Path::new("../../firmware/pac/src/lib.rs"))?;
+    gen_cm(Path::new("../../../shared/cm/src/lib.rs"))?;
+    gen_nrf52(Path::new("../../../firmware/pac/src/lib.rs"))?;
 
     Ok(())
 }

--- a/shared/cm/src/lib.rs
+++ b/shared/cm/src/lib.rs
@@ -1,3 +1,3 @@
 #![no_std]
 
-compile_error!("run the `regen` tool before compiling this crate");
+compile_error!("run the `host/regen/` tool before compiling this crate");


### PR DESCRIPTION
- specify location of `regen` tool in the error message prompting the user to run it
- fix lib path in `regen/main.rs`